### PR TITLE
Use rest-client ~> 2.0

### DIFF
--- a/onesky-ruby.gemspec
+++ b/onesky-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
The `rest-client` version keeps me from using this library with Fastlane 2.54.3

```
In Gemfile:
    fastlane was resolved to 2.54.3, which depends on
      google-api-client (< 0.14.0, >= 0.13.1) was resolved to 0.13.4, which depends on
        mime-types (~> 3.0)

    fastlane-plugin-onesky was resolved to 0.2.0, which depends on
      onesky-ruby was resolved to 0.0.1, which depends on
        rest-client (~> 1.7) was resolved to 1.7.0, which depends on
          mime-types (~> 2.0)
```