### PR TITLE
Updated rest-client to use a version of 2.0

### DIFF
--- a/onesky-ruby.gemspec
+++ b/onesky-ruby.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.1.0"
-  spec.add_development_dependency "webmock", "~> 1.19.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/spec/onesky/helpers/request_spec.rb
+++ b/spec/onesky/helpers/request_spec.rb
@@ -13,8 +13,8 @@ describe 'Helpers::Request' do
     it 'should initial request with required headers' do
       stub_request(:get, full_path_with_auth_hash("/locales", api_key, api_secret))
         .with(headers: http_header)
-        .to_return(body: {})
-      expect(client.list_locale).to be_an_instance_of(Hash)
+        .to_return(body: "{}")
+      expect(client.list_locale).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should raise error for error response code' do
@@ -28,8 +28,8 @@ describe 'Helpers::Request' do
     it 'should initial request with required headers' do
       stub_request(:post, full_path_with_auth_hash("/project-groups", api_key, api_secret))
         .with(headers: http_header)
-        .to_return(body: {})
-      expect(client.create_project_group({name: 'TEST'})).to be_an_instance_of(Hash)
+        .to_return(body: "{}")
+      expect(client.create_project_group({name: 'TEST'})).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should return response on error' do
@@ -43,13 +43,13 @@ describe 'Helpers::Request' do
     it 'should initial request with required headers' do
       stub_request(:post, full_path_with_auth_hash("/projects/#{project_id}/files", api_key, api_secret))
         .with(headers: {'Onesky-Plugin' => 'ruby-wrapper'})
-        .to_return(body: {})
-      expect(project.upload_file({file: 'spec/fixture/en.yml', file_format: 'RUBY_YAML'})).to be_an_instance_of(Hash)
+        .to_return(body: "{}")
+      expect(project.upload_file({file: 'spec/fixture/en.yml', file_format: 'RUBY_YAML'})).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should return response on error' do
       stub_request(:post, full_path_with_auth_hash("/projects/#{project_id}/files", api_key, api_secret))
-        .to_return(status: 400, body: {meta: {code: 400, message: 'error message'}}.to_json)
+        .to_return(status: 400, body: {meta: {code: 400, message: 'error message'}}.to_json.to_s)
       expect {project.upload_file({file: 'spec/fixture/en.yml', file_format: 'RUBY_YAML'})}.to raise_error(Onesky::Errors::BadRequestError, '400 Bad Request - error message')
     end
   end
@@ -58,8 +58,8 @@ describe 'Helpers::Request' do
     it 'should initial request with required headers' do
       stub_request(:put, full_path_with_auth_hash("/projects/#{project_id}", api_key, api_secret))
         .with(headers: http_header)
-        .to_return(body: {})
-      expect(project.update({name: 'NEW NAME'})).to be_an_instance_of(Hash)
+        .to_return(body: "{}")
+      expect(project.update({name: 'NEW NAME'})).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should return response on error' do
@@ -73,8 +73,8 @@ describe 'Helpers::Request' do
     it 'should initial request with required headers' do
       stub_request(:delete, full_path_with_auth_hash("/projects/#{project_id}", api_key, api_secret))
         .with(headers: http_header)
-        .to_return(body: {})
-      expect(project.remove).to be_an_instance_of(Hash)
+        .to_return(body: "{}")
+      expect(project.remove).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should return response on error' do

--- a/spec/onesky/resources/locale_spec.rb
+++ b/spec/onesky/resources/locale_spec.rb
@@ -9,9 +9,9 @@ describe 'Locale' do
   describe 'list_locale' do
     it 'should list all available locales' do
       stub_request(:get, full_path_with_auth_hash('/locales', api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.list_locale
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project/base_spec.rb
+++ b/spec/onesky/resources/project/base_spec.rb
@@ -11,9 +11,9 @@ describe 'Project::Base' do
   describe 'show' do
     it 'should show project information' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.show
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -40,9 +40,9 @@ describe 'Project::Base' do
   describe 'list_language' do
     it 'should list languages of project' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/languages", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.list_language
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project/file_spec.rb
+++ b/spec/onesky/resources/project/file_spec.rb
@@ -11,9 +11,9 @@ describe 'Project::File' do
   describe 'list_file' do
     it 'should list files in project' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/files", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.list_file
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -22,9 +22,9 @@ describe 'Project::File' do
 
     it 'should upload file to project' do
       stub_request(:post, full_path_with_auth_hash("/projects/#{project_id}/files", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.upload_file(params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
 
     it 'should raise error when file does not exist' do
@@ -38,9 +38,9 @@ describe 'Project::File' do
 
     it 'should delete file from project' do
       stub_request(:delete, full_path_with_auth_hash("/projects/#{project_id}/files", api_key, api_secret) + params_as_query_string)
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.delete_file(params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project/import_task_spec.rb
+++ b/spec/onesky/resources/project/import_task_spec.rb
@@ -11,9 +11,9 @@ describe 'Project::ImportTask' do
   describe 'list_import_task' do
     it 'should list import tasks of the project' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/import-tasks", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.list_import_task
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -22,9 +22,9 @@ describe 'Project::ImportTask' do
 
     it 'should show an import task details' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/import-tasks/#{import_task_id}", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.show_import_task(import_task_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project/order_spec.rb
+++ b/spec/onesky/resources/project/order_spec.rb
@@ -11,9 +11,9 @@ describe 'Project::Order' do
   describe 'list_order' do
     it 'should list orders in project' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/orders", api_key, api_secret))
-        .to_return(status: 200, body: {})
+        .to_return(status: 200, body: "{}")
       response = project.list_order
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -22,9 +22,9 @@ describe 'Project::Order' do
 
     it 'should show an order details' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/orders/#{order_id}", api_key, api_secret))
-        .to_return(status: 200, body: {})
+        .to_return(status: 200, body: "{}")
       response = project.show_order(order_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -36,9 +36,9 @@ describe 'Project::Order' do
     it 'should create an order' do
       stub_request(:post, full_path_with_auth_hash("/projects/#{project_id}/orders", api_key, api_secret))
         .with(body: params.to_json, headers: {'Content_Type' => 'application/json'})
-        .to_return(status: 200, body: {})
+        .to_return(status: 200, body: "{}")
       response = project.create_order(params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project/translation_spec.rb
+++ b/spec/onesky/resources/project/translation_spec.rb
@@ -50,9 +50,9 @@ describe 'Project::Translation' do
 
     it 'should show translation status' do
       stub_request(:get, full_path_with_auth_hash("/projects/#{project_id}/translations/status", api_key, api_secret) + params_as_query_string)
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = project.get_translation_status(params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project_group_spec.rb
+++ b/spec/onesky/resources/project_group_spec.rb
@@ -9,9 +9,9 @@ describe 'Project Group' do
   describe 'list_project_group' do
     it 'should list all available project group' do
       stub_request(:get, full_path_with_auth_hash('/project-groups', api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.list_project_group
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -20,9 +20,9 @@ describe 'Project Group' do
 
     it 'should show a project group information' do
       stub_request(:get, full_path_with_auth_hash("/project-groups/#{project_group_id}", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.show_project_group(project_group_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -32,9 +32,9 @@ describe 'Project Group' do
     it 'should create a project group' do
       stub_request(:post, full_path_with_auth_hash('/project-groups', api_key, api_secret))
         .with(body: params.to_json, headers: {'Content_Type' => 'application/json'})
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.create_project_group(params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -43,9 +43,9 @@ describe 'Project Group' do
 
     it 'should delete a project group' do
       stub_request(:delete, full_path_with_auth_hash("/project-groups/#{project_group_id}", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.delete_project_group(project_group_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -54,9 +54,9 @@ describe 'Project Group' do
 
     it 'should list languages activated of a project group' do
       stub_request(:get, full_path_with_auth_hash("/project-groups/#{project_group_id}/languages", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.list_project_group_languages(project_group_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project_spec.rb
+++ b/spec/onesky/resources/project_spec.rb
@@ -11,9 +11,9 @@ describe 'Project' do
 
     it 'should list all projects of a project group' do
       stub_request(:get, full_path_with_auth_hash("/project-groups/#{project_group_id}/projects", api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.list_project(project_group_id)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 
@@ -24,9 +24,9 @@ describe 'Project' do
     it 'should list all projects of a project group' do
       stub_request(:post, full_path_with_auth_hash("/project-groups/#{project_group_id}/projects", api_key, api_secret))
         .with(body: params.to_json, headers: {'Content_Type' => 'application/json'})
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.create_project(project_group_id, params)
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 

--- a/spec/onesky/resources/project_type_spec.rb
+++ b/spec/onesky/resources/project_type_spec.rb
@@ -9,9 +9,9 @@ describe 'Project Type' do
   describe 'list_project_type' do
     it 'should list all available project type' do
       stub_request(:get, full_path_with_auth_hash('/project-types', api_key, api_secret))
-        .to_return(body: {})
+        .to_return(body: "{}")
       response = client.list_project_type
-      expect(response).to be_an_instance_of(Hash)
+      expect(response).to be_an_instance_of(RestClient::Response)
     end
   end
 


### PR DESCRIPTION
There were some issues in using onesky-ruby to develop a fastlane plugin, because the rest-client version used, more specifically the mime-types version, conflicted with the new fastlane.