### PR TITLE
Update rest-client to fix bug with TLS ciphers

### DIFF
--- a/onesky-ruby.gemspec
+++ b/onesky-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 2.0'
+  spec.add_dependency 'rest-client', '~> 2.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
We're experiencing this bug running this gem in Circle: https://github.com/rest-client/rest-client/issues/612

It looks like the fix is to update rest-client to 2.0.1. I'm not sure if this is the right way to do this, thanks for being gentle!