### PR TITLE
Required Ruby version in gemspec lowered to 2.5

### DIFF
--- a/onesky-ruby.gemspec
+++ b/onesky-ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/onesky/onesky-ruby"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Please allow using this gem with Ruby 2.5, as it still works perfectly with this version