### PR TITLE
Fix Ruby 3 compatibility

### DIFF
--- a/lib/onesky/resources/project/file_mgt.rb
+++ b/lib/onesky/resources/project/file_mgt.rb
@@ -9,7 +9,7 @@ module Resources
       def upload_file(params)
         file = params[:file]
         if file.is_a?(String)
-          raise IOError, 'File does not exist' unless File.exists?(file)
+          raise IOError, 'File does not exist' unless File.exist?(file)
           params[:file] = File.new(file, 'rt')
         end
 


### PR DESCRIPTION
`File.exists?` is deprecated in Ruby 2.x and removed in Ruby 3.

This PR fixes file upload being broken when running under Ruby 3.